### PR TITLE
Add module info via moditect

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,30 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<extensions>true</extensions>
 			</plugin>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <version>1.0.0.Final</version>
+        <executions>
+          <execution>
+            <id>add-module-infos</id>
+            <goals>
+              <goal>add-module-info</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <jvmVersion>9</jvmVersion>
+              <module>
+                <moduleInfo>
+                  <name>net.jcip.annotations</name>
+                  <exports>net.jcip.annotations;</exports>
+                </moduleInfo>
+              </module>
+              <overwriteExistingFiles>true</overwriteExistingFiles>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
 		</plugins>
   </build>
 


### PR DESCRIPTION
I am opening two PRs. Currently, i'm working through the transitive dependencies of Spring to get closer to all of spring being able to be used with jlink.

This is one of those transitive deps.

On this branch I added a module-info via moditect. This would keep the annotations compiled at bytecode level 5. On the other PR I will do the same, but just bump the java version up to the minimum required for a module-info. 

As its kinda hard to get a JVM that can compile java 5 code, this solution was hard for me to verify.

https://spring-modularization.netlify.app/
<img width="590" alt="image" src="https://github.com/stephenc/jcip-annotations/assets/5004262/fb13a273-edd7-4583-8368-436b858d2065">
