### PR TITLE
Add module info via updating Java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,8 +140,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>9</source>
+          <target>9</target>
         </configuration>
       </plugin>
 			<plugin>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,3 @@
+module net.jcip.annotations {
+    exports net.jcip.annotations;
+}


### PR DESCRIPTION
This is a companion to #7 (and there are more options than these)

This adds a module info by bumping the Java version to the minimum required for that (9) and just adding the module descriptor